### PR TITLE
Replace currentLocation with trackMyPosition in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add the following to your `pubspec.yaml` file:
 ```dart
  OSMFlutter( 
         controller:mapController,
-        currentLocation: false,
+        trackMyPosition: false,
         road: Road(
                 startIcon: MarkerIcon(
                   icon: Icon(


### PR DESCRIPTION
In the readme file simple usage example, there is a boolean argument passed to currentLocation parameter in OSMFlutter widget which doesnot exists. I have replaced it with the trackMyPosition parameter in this pull request. Thank you.