### PR TITLE
Error caused when loadingWidget is not null is solved

### DIFF
--- a/lib/src/osm_flutter.dart
+++ b/lib/src/osm_flutter.dart
@@ -168,7 +168,7 @@ class OSMFlutterState extends State<OSMFlutter> {
                         Container(
                           color: Colors.white,
                           child: buildWidget(
-                              controller: widget.controller as MapController,
+                              controller: widget.controller,
                               onGeoPointClicked: widget.onGeoPointClicked,
                               onLocationChanged: widget.onLocationChanged,
                               dynamicMarkerWidgetNotifier: dynamicMarkerWidgetNotifier,

--- a/lib/src/widgets/custom_picker_location.dart
+++ b/lib/src/widgets/custom_picker_location.dart
@@ -41,18 +41,28 @@ class CustomPickerLocationConfig {
 class CustomPickerLocation extends StatefulWidget {
   final PickerMapController controller;
   final AppBar? appBarPicker;
+  final Widget? customPicker;
   final Widget? topWidgetPicker;
   final Widget? bottomWidgetPicker;
   final CustomPickerLocationConfig pickerConfig;
+  final  Function(bool)? onMapReady;
 
   CustomPickerLocation({
     required this.controller,
     this.appBarPicker,
+    this.customPicker,
     this.bottomWidgetPicker,
     this.topWidgetPicker,
     this.pickerConfig = const CustomPickerLocationConfig(),
+    this.onMapReady,
     Key? key,
-  }) : super(key: key);
+  }) : assert(appBarPicker != null || customPicker != null,
+         ' one of these parameters should not be null; appBarPicker, customPicker'
+       ),
+        assert(appBarPicker == null || customPicker == null,
+         'You should not provide both a appBarPicker and customPicker parameters at the same time'
+    
+       ), super(key: key);
 
   static PickerMapController of<T>(
     BuildContext context, {
@@ -108,16 +118,30 @@ class _CustomPickerLocationState extends State<CustomPickerLocation> {
                   initZoom: widget.pickerConfig.initZoom,
                   minZoomLevel: widget.pickerConfig.minZoomLevel,
                   maxZoomLevel: widget.pickerConfig.maxZoomLevel,
+                  onMapIsReady:widget.onMapReady
                 ),
               ),
-              if (widget.topWidgetPicker != null) ...[
-                Positioned(
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  child: widget.topWidgetPicker!,
-                ),
-              ],
+               if(widget.customPicker != null)
+              Positioned(
+                top:50,
+                left:10,
+                right:10,
+                child:Column(children:[
+                       widget.customPicker!,
+                      if (widget.topWidgetPicker != null)
+                         widget.topWidgetPicker!
+                ]))
+                else if (widget.topWidgetPicker != null) ...[
+                    Positioned(
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      child: widget.topWidgetPicker!,
+                    ),
+                  ],
+
+              
+
               if (widget.bottomWidgetPicker != null) ...[
                 widget.bottomWidgetPicker!,
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,11 +16,15 @@ dependencies:
   url_launcher: ^6.0.10
   dio: ^4.0.0
   uuid: ^3.0.5
-  flutter_osm_interface:
-    path: ./flutter_osm_interface
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter
+    
+  flutter_osm_interface:
+    git:
+      url: https://github.com/xyzbilal/osm_flutter.git
+      path: flutter_osm_interface
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Hi, sory for my novice for ccreating merge request because I m not experienced that enough.
Adding loadingWidget causes an error casting CustomController to MapController and
add some new features that onMapReady callback function and enables developer to provide custom picker as shown in picture. 

!! Please discard changes in pubspec.yaml. I just tried to add my forked repository but get error about  path  of flutter_osm_interface defined in pubspec yaml!!
![Simulator Screen Shot - iPhone 11 Pro - 2022-03-16 at 14 03 58](https://user-images.githubusercontent.com/18241412/158586713-bea9bd29-3d22-4059-b685-899e8f2f3855.png)
 