### PR TITLE
Change currentPosition() to currentLocation() solves : #329

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ for more example see our example in `home_example.dart`
 <b>4) Set map on user current position </b>
 
 ```dart
- await controller.currentPosition();
+ await controller.currentLocation();
 
 ```
 <b> 5) Zoom IN </b>


### PR DESCRIPTION
#329 
Replace  `currentPosition()` by  `currentLocation()` in the Readme.md file 4.1) section. 

The method `currentPosition()` does not exist now, but the method `currentLocation()` works and gives the desired output.

![image](https://user-images.githubusercontent.com/47064215/188454761-eb62f647-2b3a-4119-8ed2-8720a93b7082.png)

The method `currentLocation()` works just fine.

![image](https://user-images.githubusercontent.com/47064215/188455089-01cd3381-b284-4ad6-a5f5-cc89a5209510.png)


