### PR TITLE
Fix example app to run on flutter version 3.10 and dart version 3.0.0

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_osm_plugin_example/src/search_example.dart';
 import 'package:flutter_osm_plugin_example/src/simple_example_hook.dart';
 
 //import 'src/adv_home/home_example.dart';
 import 'src/home/home_example.dart';
-import 'src/search_example.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,12 +8,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_dotenv: ^5.0.2
   flutter_osm_plugin: #^0.40.3+2
     path: ../
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.5
   flutter_hooks: ^0.18.5+1
   osm_flutter_hooks: ^1.0.0
   pointer_interceptor: ^0.9.3+3
@@ -40,7 +39,6 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
      - asset/
-     - .env
   #  - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
With the recent release of dart, the non-nullsafe code is not allowed. So this PR fixes the example app so that it runs with the latest flutter version.