### PR TITLE
fix drawMultipleRoad color not working properly #472

### DIFF
--- a/flutter_osm_web/lib/src/mixin_web.dart
+++ b/flutter_osm_web/lib/src/mixin_web.dart
@@ -352,7 +352,7 @@ mixin WebMixin {
           config.startPoint,
           config.destinationPoint,
           interestPoints: config.intersectPoints,
-          roadOption: commonRoadOption,
+          roadOption: config.roadOptionConfiguration ?? commonRoadOption,
         ),
       );
     });


### PR DESCRIPTION
In Web, it will check if the config.roadOptionConfiguration is set, else it will add the default one.

