### PR TITLE
remove usage of canLaunchUrl

### DIFF
--- a/lib/src/widgets/copyright_osm_widget.dart
+++ b/lib/src/widgets/copyright_osm_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class CopyrightOSMWidget extends StatelessWidget {
@@ -28,13 +29,12 @@ class CopyrightOSMWidget extends StatelessWidget {
               ),
               recognizer: TapGestureRecognizer()
                 ..onTap = () async {
-                  final url = 'https://www.openstreetmap.org/copyright';
-                  if (await canLaunchUrlString(url)) {
+                  try {
                     await launchUrlString(
-                      url,
+                      'https://www.openstreetmap.org/copyright',
                       mode: LaunchMode.externalApplication,
                     );
-                  }
+                  } on PlatformException {}
                 },
               children: [
                 TextSpan(


### PR DESCRIPTION
Using `canLaunchUrl` when there's no fallback is [not recommended](https://pub.dev/packages/url_launcher#checking-supported-schemes) as on some platforms, `canLaunchUrl` is unreliable in some cases, and/or requires extra permissions that `launchUrl` does not. This PR removes the pre-checking and just tries to open the copyright page. If there are failures, these are silently ignored (as before).

A similar change was made to the `Link` widget in url_launcher: https://github.com/flutter/packages/commit/3eaad3d0d1ecbf8425b72a28b150c013781ee4fa

I wasn't sure about the target branch as master seems to be out-of-date, so I just opened this PR against 0.70.3. Feel free to change the base branch if needed.