### PR TITLE
fix null pointer exception in map drawing

### DIFF
--- a/android/src/main/kotlin/hamza/dali/flutter_osm_plugin/overlays/CustomLocation.kt
+++ b/android/src/main/kotlin/hamza/dali/flutter_osm_plugin/overlays/CustomLocation.kt
@@ -156,9 +156,11 @@ class CustomLocationManager(mapView: MapView) : MyLocationNewOverlay(mapView) {
                 }
             }
             else -> {
-                when (lastFix.hasBearing()) {
-                    true -> drawDirection(canvas, pProjection, lastFix)
-                    else -> drawPerson(canvas, pProjection, lastFix)
+                if (lastFix != null) {
+                    when (lastFix.hasBearing()) {
+                        true -> drawDirection(canvas, pProjection, lastFix)
+                        else -> drawPerson(canvas, pProjection, lastFix)
+                    }
                 }
             }
         }


### PR DESCRIPTION
In the test setup of #482, every move of the map resulted in a null pointer exception. This commit adds a null check to fix it.