### PR TITLE
Improvements to addressSuggestion and Address

### DIFF
--- a/flutter_osm_interface/lib/src/types/search_completion.dart
+++ b/flutter_osm_interface/lib/src/types/search_completion.dart
@@ -29,28 +29,32 @@ class Address {
         this.country = data["country"];
 
   @override
-  String toString() {
-    String addr = "";
+  String toString({String separator = ","}) {
+    List<String> addr = [];
     if (name != null && name!.isNotEmpty) {
-      addr = addr + "$name,";
+      addr.add(name!);
     }
     if (street != null && street!.isNotEmpty) {
-      addr = addr + "$street,";
+      if (housenumber != null && housenumber!.isNotEmpty) {
+        addr.add("$street $housenumber");
+      } else {
+        addr.add(street!);
+      }
     }
     if (postcode != null && postcode!.isNotEmpty) {
-      addr = addr + "$postcode,";
+      addr.add(postcode!);
     }
     if (city != null && city!.isNotEmpty) {
-      addr = addr + "$city,";
+      addr.add(city!);
     }
     if (state != null && state!.isNotEmpty) {
-      addr = addr + "$state,";
+      addr.add(state!);
     }
     if (country != null && country!.isNotEmpty) {
-      addr = addr + "$country";
+      addr.add(country!);
     }
 
-    return addr;
+    return addr.join(separator);
   }
 }
 

--- a/flutter_osm_interface/lib/src/types/search_completion.dart
+++ b/flutter_osm_interface/lib/src/types/search_completion.dart
@@ -4,6 +4,7 @@ class Address {
   final String? postcode;
   final String? name;
   final String? street;
+  final String? housenumber;
   final String? city;
   final String? state;
   final String? country;
@@ -11,6 +12,7 @@ class Address {
   Address({
     this.postcode,
     this.street,
+    this.housenumber,
     this.city,
     this.name,
     this.state,
@@ -21,6 +23,7 @@ class Address {
       : this.postcode = data["postcode"],
         this.name = data["name"],
         this.street = data["street"],
+        this.housenumber = data["housenumber"],
         this.city = data["city"],
         this.state = data["state"],
         this.country = data["country"];

--- a/lib/src/common/utilities.dart
+++ b/lib/src/common/utilities.dart
@@ -44,12 +44,13 @@ Future<double> distance2point(GeoPoint p1, GeoPoint p2) async {
 }
 
 Future<List<SearchInfo>> addressSuggestion(String searchText,
-    {int limitInformation = 5}) async {
+    {int limitInformation = 5, String locale = ""}) async {
   Response response = await Dio().get(
     "https://photon.komoot.io/api/",
     queryParameters: {
       "q": searchText,
-      "limit": limitInformation == 0 ? "" : "$limitInformation"
+      "limit": limitInformation == 0 ? "" : "$limitInformation",
+      "lang": locale
     },
   );
   final json = response.data;


### PR DESCRIPTION
While searching for a `google_places_flutter` replacement, I noticed that this plugin already contains the ability to search for an address.

But somehow the address did not contain the street, and I couldn't make the search in German.

This small PR fixes both. It also adds the ability to use a custom separator between the Address elements in toString().