### PR TITLE
Fix example code at simple usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,49 +101,47 @@ many thanks for @ben-xD
   
   
 ```dart
- OSMFlutter( 
-        controller:mapController,
-        osmOption: OSMOption(
-              userTrackingOption: UserTrackingOption(
-              enableTracking: true,
-              unFollowUser: false,
-            ),
-            zoomOption: ZoomOption(
-                  initZoom: 8,
-                  minZoomLevel: 3,
-                  maxZoomLevel: 19,
-                  stepZoom: 1.0,
-            ),
-            userLocationMarker: UserLocationMaker(
-                personMarker: MarkerIcon(
-                    icon: Icon(
-                        Icons.location_history_rounded,
-                        color: Colors.red,
-                        size: 48,
-                    ),
-                ),
-                directionArrowMarker: MarkerIcon(
-                    icon: Icon(
-                        Icons.double_arrow,
-                        size: 48,
-                    ),
-                ),
-            ),
-            roadConfiguration: RoadOption(
-                    roadColor: Colors.yellowAccent,
-            ),
-            markerOption: MarkerOption(
-                defaultMarker: MarkerIcon(
-                    icon: Icon(
-                      Icons.person_pin_circle,
-                      color: Colors.blue,
-                      size: 56,
-                    ),
-                )
-            ),
-        )
-    );
-
+OSMFlutter(
+  controller: MapController(
+    initPosition: GeoPoint(latitude: 47.4358055, longitude: 8.4737324),
+    areaLimit: const BoundingBox(
+      east: 10.4922941,
+      north: 47.8084648,
+      south: 45.817995,
+      west: 5.9559113,
+    ),
+  ),
+  osmOption: OSMOption(
+    userTrackingOption: const UserTrackingOption(
+      enableTracking: true,
+      unFollowUser: false,
+    ),
+    zoomOption: const ZoomOption(
+      initZoom: 8,
+      minZoomLevel: 3,
+      maxZoomLevel: 19,
+      stepZoom: 1.0,
+    ),
+    userLocationMarker: UserLocationMaker(
+      personMarker: const MarkerIcon(
+        icon: Icon(
+          Icons.location_history_rounded,
+          color: Colors.red,
+          size: 48,
+        ),
+      ),
+      directionArrowMarker: const MarkerIcon(
+        icon: Icon(
+          Icons.double_arrow,
+          size: 48,
+        ),
+      ),
+    ),
+    roadConfiguration: const RoadOption(
+      roadColor: Colors.yellowAccent,
+    ),
+  ),
+)
 ```
 
 ## MapController


### PR DESCRIPTION
Remove deprecated API `markerOption` in **Simple Usage** example code. 

Fix #580 