### PR TITLE
Fix crash getZoom on iOS

### DIFF
--- a/flutter_osm_interface/lib/src/channel/osm_method_channel.dart
+++ b/flutter_osm_interface/lib/src/channel/osm_method_channel.dart
@@ -503,7 +503,7 @@ class MethodChannelOSM extends MobileOSMPlatform {
 
   @override
   Future<double> getZoom(int idOSM) async {
-    return await _channels[idOSM]?.invokeMethod('get#Zoom');
+    return (await _channels[idOSM]?.invokeMethod('get#Zoom')).toDouble();
   }
 
   @override


### PR DESCRIPTION
Add cast from int to double.