### PR TITLE
Update osm_map.swift

### DIFF
--- a/ios/flutter_osm_plugin/Sources/flutter_osm_plugin/map_view/osm_map.swift
+++ b/ios/flutter_osm_plugin/Sources/flutter_osm_plugin/map_view/osm_map.swift
@@ -695,6 +695,18 @@ class MapCoreOSMView : NSObject, FlutterPlatformView, CLLocationManagerDelegate,
         }
        
     }
+    
+    func onMarkerSingleTap(location: CLLocationCoordinate2D) {
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("receiveSinglePress", arguments: location.toGeoPoint())
+        }
+    }
+    
+    func onMarkerLongPress(location: CLLocationCoordinate2D) {
+        DispatchQueue.main.async {
+            self.channel.invokeMethod("receiveLongPress", arguments: location.toGeoPoint())
+        }
+    }
 }
 extension MapCoreOSMView {
     func drawRoadMCOSM(call: FlutterMethodCall, completion: @escaping (_ roadInfo: RoadInformation?, _ road: Road?, _ roadData: RoadData , _ boundingBox: BoundingBox?,_ polyline: Polyline?, _ error: Error?) -> ()) {


### PR DESCRIPTION
Added new methods to fix iOS build due new OSMMapCoreIOSFramework version (0.8.4)

The current version is getting the new OSMMapCoreIOSFramework version, probably this is not the correct fix, the version on SPM should be fixed instead of get the version >= 0.7.4 <1.0.0